### PR TITLE
Update keymapping on badge

### DIFF
--- a/Software/dczia26_final/dczia26_keypad.cpp
+++ b/Software/dczia26_final/dczia26_keypad.cpp
@@ -7,10 +7,10 @@ const byte ROWS = 4; //four rows
 const byte COLS = 4; //four columns
 //define the cymbols on the buttons of the keypads
 char hexaKeys[ROWS][COLS] = {
-  {KEY_R3C3, KEY_R3C2, KEY_R3C1, KEY_R3C0},
-  {KEY_R2C3, KEY_R2C2, KEY_R2C1, KEY_R2C0},
-  {KEY_R1C3, KEY_R1C2, KEY_R1C1, KEY_R1C0},
-  {KEY_R0C3, KEY_R0C2, KEY_R0C1, KEY_R0C0}
+  {KEY_R0C0, KEY_R0C1, KEY_R0C2, KEY_R0C3},
+  {KEY_R1C0, KEY_R1C1, KEY_R1C2, KEY_R1C3},
+  {KEY_R2C0, KEY_R2C1, KEY_R2C2, KEY_R2C3},
+  {KEY_R3C0, KEY_R3C1, KEY_R3C2, KEY_R3C3}
 };
 byte rowPins[ROWS] = {17,  16,  4, 2}; //connect to the row pinouts of the keypad
 byte colPins[COLS] = {32, 33, 25, 26}; //connect to the column pinouts of the keypad

--- a/Software/dczia26_final/dczia26_led.h
+++ b/Software/dczia26_final/dczia26_led.h
@@ -21,22 +21,22 @@ void startupAnimation();
 void FadeInFadeOutRinseRepeat(float luminance);
 
 // LED array-to-matrix mapping
-#define LED_R0C0 15
-#define LED_R0C1 14
-#define LED_R0C2 13
-#define LED_R0C3 12
-#define LED_R1C0 11
-#define LED_R1C1 10
-#define LED_R1C2 9
-#define LED_R1C3 8
-#define LED_R2C0 7
-#define LED_R2C1 6
-#define LED_R2C2 5
-#define LED_R2C3 4
-#define LED_R3C0 3
-#define LED_R3C1 2
-#define LED_R3C2 1
-#define LED_R3C3 0
+#define LED_R0C0 0
+#define LED_R0C1 1
+#define LED_R0C2 2
+#define LED_R0C3 3
+#define LED_R1C0 4
+#define LED_R1C1 5
+#define LED_R1C2 6
+#define LED_R1C3 7
+#define LED_R2C0 8
+#define LED_R2C1 9
+#define LED_R2C2 10
+#define LED_R2C3 11
+#define LED_R3C0 12
+#define LED_R3C1 13
+#define LED_R3C2 14
+#define LED_R3C3 15
 
 
 


### PR DESCRIPTION
Why:
  * Top left button on badge thinks it is bottom left

How:
  * Change keypad to be on Column/Row order
  * Change LEDs to map to new ordering